### PR TITLE
Allow to override host and broadcast address for nsqd and nsqdlookupd.

### DIFF
--- a/lib/nsq-cluster.rb
+++ b/lib/nsq-cluster.rb
@@ -22,6 +22,7 @@ class NsqCluster
   def initialize(opts = {})
     opts = {
       nsqlookupd_count: 0,
+      nsqdlookupd_options: {},
       nsqd_count: 0,
       nsqadmin: false,
       nsqd_options: {},
@@ -30,7 +31,7 @@ class NsqCluster
 
     @silent = opts[:silent]
 
-    @nsqlookupd = create_nsqlookupds(opts[:nsqlookupd_count])
+    @nsqlookupd = create_nsqlookupds(opts[:nsqlookupd_count], opts[:nsqdlookupd_options])
     @nsqd = create_nsqds(opts[:nsqd_count], opts[:nsqd_options])
     @nsqadmin = create_nsqadmin if opts[:nsqadmin]
 
@@ -39,13 +40,13 @@ class NsqCluster
   end
 
 
-  def create_nsqlookupds(count)
+  def create_nsqlookupds(count, options)
     (0...count).map do |idx|
-      Nsqlookupd.new(
+      Nsqlookupd.new(options.merge({
         tcp_port: 4160 + idx * 2,
         http_port: 4161 + idx * 2,
         silent: @silent
-      )
+      }))
     end
   end
 

--- a/lib/nsq-cluster/nsqd.rb
+++ b/lib/nsq-cluster/nsqd.rb
@@ -10,11 +10,12 @@ class Nsqd < ProcessWrapper
 
 
   def initialize(opts = {})
-    @host = '127.0.0.1'
+    @host = opts[:host] || '127.0.0.1'
     @tcp_port = opts[:tcp_port] || 4150
     @http_port = opts[:http_port] || 4151
     @lookupd = opts[:nsqlookupd] || []
     @msg_timeout = opts[:msg_timeout] || '60s'
+    @broadcast_address = opts[:broadcast_address] || @host
 
     clear_data_directory
     create_data_directory
@@ -40,7 +41,8 @@ class Nsqd < ProcessWrapper
       %Q(--http-address=#{@host}:#{@http_port}),
       %Q(--data-path=#{data_path}),
       %Q(--worker-id=#{worker_id}),
-      %Q(--msg-timeout=#{@msg_timeout})
+      %Q(--msg-timeout=#{@msg_timeout}),
+      %Q(--broadcast-address=#{@broadcast_address})
     ]
 
     lookupd_args = @lookupd.map do |ld|

--- a/lib/nsq-cluster/nsqlookupd.rb
+++ b/lib/nsq-cluster/nsqlookupd.rb
@@ -7,9 +7,10 @@ class Nsqlookupd < ProcessWrapper
   attr_reader :host, :tcp_port, :http_port
 
   def initialize(opts = {})
-    @host = '127.0.0.1'
+    @host = opts[:host] || '127.0.0.1'
     @tcp_port = opts[:tcp_port] || 4160
     @http_port = opts[:http_port] || 4161
+    @broadcast_address = opts[:broadcast_address] || @host
 
     super
   end
@@ -23,7 +24,8 @@ class Nsqlookupd < ProcessWrapper
   def args
     [
       %Q(--tcp-address=#{@host}:#{@tcp_port}),
-      %Q(--http-address=#{@host}:#{@http_port})
+      %Q(--http-address=#{@host}:#{@http_port}),
+      %Q(--broadcast-address=#{@broadcast_address})
     ]
   end
 


### PR DESCRIPTION
broadcast-address auto-detection doesn't work properly sometimes and it defaults to the external IP instead of 127.0.01. This commit allows to override host and broadcast_address for nsqd and nsqlookupd.
