### PR TITLE
adding ability to pause the nsqd process to make timeouts testable

### DIFF
--- a/lib/nsq-cluster/process_wrapper.rb
+++ b/lib/nsq-cluster/process_wrapper.rb
@@ -5,6 +5,7 @@ class ProcessWrapper
 
   def initialize(opts = {}, verbose = false)
     @verbose = verbose
+    @process_paused = false
   end
 
 
@@ -17,10 +18,23 @@ class ProcessWrapper
 
   def stop(opts = {})
     raise "#{command} is not running" unless running?
+    Process.kill('CONT', @pid) if @process_paused
     Process.kill('TERM', @pid)
     Process.waitpid(@pid)
     @pid = nil
     block_until_stopped unless opts[:async]
+  end
+
+  def pause_process(opts = {})
+    raise "#{command} is not running" unless running?
+    @process_paused = true
+    Process.kill('TSTP', @pid)
+  end
+
+  def resume_process(opts = {})
+    raise "#{command} is not running" unless running?
+    @process_paused = false
+    Process.kill('CONT', @pid)
   end
 
 


### PR DESCRIPTION
I tried the specs but there are some ruby issues it seems with fakeweb


`NoMethodError:
              undefined method `<<' for {:read_timeout=>60, :continue_timeout=>nil, :debug_output=>nil}:Hash
              Did you mean?  <
            # ./vendor/bundle/ruby/2.4.0/gems/fakeweb-1.3.0/lib/fake_web/ext/net_http.rb:50:in `request_with_fakeweb'
`